### PR TITLE
Optimized version with vectorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Original project: https://gitlab.citius.usc.es/lidar/rule-based-classifier.
     Get 1.15 source code from  `https://github.com/PointCloudLibrary/pcl/releases` and build it. The folder were I installed it is `~/local/pcl`, but that can be changed to any other folder, with an appropiate change in `CMakeLibraries.cmake`. Can also change the version to look for in that file.
     ```bash
     wget https://github.com/PointCloudLibrary/pcl/releases/download/pcl-1.15.0/source.tar.gz
-    tar xvf sources.tar.gz
+    tar xvf source.tar.gz
     cd pcl && mkdir build && cd build
     cmake .. -DCMAKE_INSTALL_PREFIX=$HOME/local/pcl -DCMAKE_BUILD_TYPE=Release
     make -j2

--- a/cmake/CMakeBuildExec.cmake
+++ b/cmake/CMakeBuildExec.cmake
@@ -42,5 +42,10 @@ target_link_libraries(${PROJECT_NAME}
 target_link_libraries(${PROJECT_NAME} PRIVATE ${PAPI_LIBRARY})
 target_include_directories(${PROJECT_NAME} PRIVATE ${PAPI_INCLUDE_DIR})
 
+# Añadimos linkeo de pthread y atomic para resolver errores
+find_package(Threads REQUIRED)
+target_link_libraries(${PROJECT_NAME} PRIVATE Threads::Threads atomic)
+
 # Set Link Time Optimization (LTO)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -flto=auto")
+

--- a/cmake/CMakeConfig.cmake
+++ b/cmake/CMakeConfig.cmake
@@ -2,6 +2,7 @@
 # --------------------- #
 
 include(CheckCXXCompilerFlag)
+
 CHECK_CXX_COMPILER_FLAG("-mavx2" COMPILER_SUPPORTS_AVX2)
 
 if(COMPILER_SUPPORTS_AVX2)
@@ -10,20 +11,51 @@ else()
     message(WARNING "AVX2 not supported by the compiler")
 endif()
 
-include(CheckCXXCompilerFlag)
+
 CHECK_CXX_COMPILER_FLAG("-mbmi2" COMPILER_SUPPORTS_BMI2)
 
 if(COMPILER_SUPPORTS_BMI2)
     set(BMI2_FLAGS "-mbmi2")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${BMI2_FLAGS}")
 else()
     message(WARNING "BMI2 not supported by the compiler")
 endif()
 
 
+CHECK_CXX_COMPILER_FLAG("-mavx512f" COMPILER_SUPPORTS_AVX512F)
+
+if(COMPILER_SUPPORTS_AVX512F)
+    set(AVX512_FLAGS "-mavx512f")
+else()
+    message(WARNING "AVX-512 not supported by the compiler")
+endif()
+
+CHECK_CXX_COMPILER_FLAG("-mavx512dq" COMPILER_SUPPORTS_AVX512DQ)
+
+if(COMPILER_SUPPORTS_AVX512DQ)
+    set(AVX512DQ_FLAGS "-mavx512dq")
+else()
+    message(WARNING "AVX-512DQ not supported by the compiler")
+endif()
+
+# Unir flags compatibles
+set(CMAKE_CXX_FLAGS "${AVX2_FLAGS} ${BMI2_FLAGS}") # Add AVX512_FLAGS and AVX512DQ_FLAGS if supported
+
 # Setup compiler flags
-set(CMAKE_CXX_FLAGS_RELEASE "-O2 -DNDEBUG -w ${AVX2_FLAGS} ${BMI2_FLAGS}")
-set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g ${AVX2_FLAGS} ${BMI2_FLAGS}")
+set(CMAKE_CXX_FLAGS_RELEASE "-O2 -DNDEBUG -w ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g ${CMAKE_CXX_FLAGS}")
+
+# new Profile build type for tool perf
+set(CMAKE_CXX_FLAGS_PROFILE "-O2 -g -fno-omit-frame-pointer ${CMAKE_CXX_FLAGS}")
+
+# Set profile type
+set(CMAKE_BUILD_TYPE "Profile" CACHE STRING "Build type")
+
+# Asignar flags si el tipo de build es "Profile"
+if(CMAKE_BUILD_TYPE STREQUAL "Profile")
+    message(STATUS "Usando configuración de build: Profile")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS_PROFILE}")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS_PROFILE}")
+endif()
 
 # CXX Standard
 set(CMAKE_CXX_STANDARD 20)

--- a/cmake/CMakeLibraries.cmake
+++ b/cmake/CMakeLibraries.cmake
@@ -47,7 +47,7 @@ endif ()
 # LASlib
 find_package(LASLIB REQUIRED)
 if (${LASLIB_FOUND})
-  include_directories(${LASLIB_INCLUDE_DIR} ${LASZIP_INCLUDE_DIR})
+  include_directories(${LASLIB_INCLUDE_DIR} ${LASZIP_INCLUDE_DIR} ${LASZIP_INCLUDE_DIR_2})
     message(STATUS "LASlib include: ${LASLIB_INCLUDE_DIR} ${LASZIP_INCLUDE_DIR}")
 else ()
     message(SEND_ERROR "Could not find LASLIB")

--- a/cmake/modules/FindLASLIB.cmake
+++ b/cmake/modules/FindLASLIB.cmake
@@ -4,16 +4,23 @@
 #  LASLIB_LIBRARIES, the libraries to link against to use the LASlib library.
 #  LASLIB_LIBRARY_DIRS, the directory where the LASlib library is found.
 
+message(STATUS "CMAKE_SOURCE_DIR = ${CMAKE_SOURCE_DIR}")
+
+
 find_path(LASLIB_INCLUDE_DIR
         lasreader.hpp
         HINTS ${CMAKE_SOURCE_DIR}/lib/LAStools/LASlib/inc)
+message(STATUS "LASLIB_INCLUDE_DIR = ${LASLIB_INCLUDE_DIR}")
+
 find_path(LASZIP_INCLUDE_DIR
         mydefs.hpp
         HINTS ${CMAKE_SOURCE_DIR}/lib/LAStools/LASzip/src)
+message(STATUS "LASZIP_INCLUDE_DIR = ${LASZIP_INCLUDE_DIR}")
 
 find_path(LASZIP_INCLUDE_DIR_2
         laszip_common.h
-        HINTS ${CMAKE_SOURCE_DIR}/lidb/LAStools/LASzip/include/laszip)
+        HINTS ${CMAKE_SOURCE_DIR}/lib/LAStools/LASzip/include/laszip)
+message(STATUS "LASZIP_INCLUDE_DIR_2 = ${LASZIP_INCLUDE_DIR_2}")
 
 if (LASLIB_INCLUDE_DIR)
     find_library(LASLIB_LIBRARY

--- a/inc/PointEncoding/hilbert_encoder_3d.hpp
+++ b/inc/PointEncoding/hilbert_encoder_3d.hpp
@@ -28,14 +28,20 @@ public:
      */
     key_t encode(coords_t x, coords_t y, coords_t z) const override {
         key_t key = 0;
+
         for(int level = MAX_DEPTH - 1; level >= 0; level--) {
+
             // Find octant and append to the key (same as Morton codes)
-            const coords_t xi = (x >> level) & 1u;
-            const coords_t yi = (y >> level) & 1u;
-            const coords_t zi = (z >> level) & 1u;
-            const coords_t octant = (xi << 2) | (yi << 1) | zi;
+            const uint32_t xi = (x >> level) & 1u;
+            const uint32_t yi = (y >> level) & 1u;
+            const uint32_t zi = (z >> level) & 1u;
+            const uint32_t octant = (xi << 2) | (yi << 1) | zi;
+
             key <<= 3;
             key |= mortonToHilbert[octant];
+            
+            // Store coordinates before XOR operations for comparison
+            uint32_t x_before = x, y_before = y, z_before = z;
             
             // Turn x, y, z (Karnaugh mapped operations, check citation and Lam and Shapiro paper detailing 2D case 
             // for understanding how this works)
@@ -43,19 +49,209 @@ public:
             y ^= -((xi & (yi | zi)) | (yi & (!zi)));
             z ^= -((xi & (!yi) & (!zi)) | (yi & (!zi)));
 
+            // Store coordinates before rotation/swap for comparison
+            uint32_t x_before_rot = x, y_before_rot = y, z_before_rot = z;
+
             if (zi) {
                 // Cylic anticlockwise rotation x, y, z -> y, z, x
-                coords_t temp = x;
+                uint32_t temp = x;
                 x = y, y = z, z = temp;
             } else if (!yi) {
                 // Swap x and z
-                coords_t temp = x;
+                uint32_t temp = x;
                 x = z, z = temp;
             }
         }
         return key;
     }
 
+#if defined(__AVX512F__) && defined(__AVX512DQ__)
+    void encodeVectorized(const uint32_t *x, const uint32_t *y, const uint32_t *z, std::vector<key_t> &keys, size_t i) const override
+    {
+        // Load the data
+        __m512i vx = _mm512_load_si512((__m512i *)x);
+        __m512i vy = _mm512_load_si512((__m512i *)y);
+        __m512i vz = _mm512_load_si512((__m512i *)z);
+
+        // Constants
+        // A constant array duplicated (for avx512 use) to map adequately rotated x, y, z coordinates to their corresponding octant
+        __m512i lookup_table_mortonToHilbert = _mm512_setr_epi32(
+            0, 1, 3, 2, 7, 6, 4, 5, // Only use this
+            0, 1, 3, 2, 7, 6, 4, 5  // Duplicated for AVX512 (not used)
+        );
+        __m512i one = _mm512_set1_epi32(1);
+
+        // Initialize 64-bit keys as 2 separate vectors since they are size_t and we are working with uint32
+        __m512i key_lo = _mm512_setzero_si512();
+        __m512i key_hi = _mm512_setzero_si512();
+
+        for (int level = MAX_DEPTH - 1; level >= 0; --level)
+        {
+            // Find octant and append to the key (same as Morton codes)
+            __m512i shift = _mm512_set1_epi32(level);
+
+            // (coord >> level) & 1u;
+            __m512i xi = _mm512_and_epi32(_mm512_srlv_epi32(vx, shift), one);
+            __m512i yi = _mm512_and_epi32(_mm512_srlv_epi32(vy, shift), one);
+            __m512i zi = _mm512_and_epi32(_mm512_srlv_epi32(vz, shift), one);
+
+            __m512i xi2 = _mm512_slli_epi32(xi, 2);
+            __m512i yi1 = _mm512_slli_epi32(yi, 1);
+            __m512i octant = _mm512_or_epi32(_mm512_or_epi32(xi2, yi1), zi);
+
+            // Utilice octant indexs (16 x [0-7]) to acces the first part of the lookup table
+            __m512i hilbertVals = _mm512_permutexvar_epi32(octant, lookup_table_mortonToHilbert);
+
+            // Expand Morton to Hilbert (16x uint32_t) to 16x uint64_t
+            __m256i lo = _mm512_castsi512_si256(hilbertVals);       // first 8
+            __m256i hi = _mm512_extracti32x8_epi32(hilbertVals, 1); // last 8
+
+            __m512i hilbertVals_lo = _mm512_cvtepu32_epi64(lo); // 8 x uint64_t
+            __m512i hilbertVals_hi = _mm512_cvtepu32_epi64(hi); // 8 x uint64_t
+
+            // Shift keys and combine them
+            key_lo = _mm512_slli_epi64(key_lo, 3);
+            key_hi = _mm512_slli_epi64(key_hi, 3);
+            key_lo = _mm512_or_si512(key_lo, hilbertVals_lo);
+            key_hi = _mm512_or_si512(key_hi, hilbertVals_hi);
+
+            // Turn x, y, z (Karnaugh mapped operations, check citation and Lam and Shapiro paper detailing 2D case
+            // for understanding how this works)
+
+            // Recompute masks
+            __m512i not_yi = _mm512_xor_epi32(yi, one);
+            __m512i not_zi = _mm512_xor_epi32(zi, one);
+
+            // X
+            __m512i cond_x = _mm512_and_epi32(xi, _mm512_or_epi32(not_yi, zi));
+            vx = _mm512_xor_epi32(vx, _mm512_maskz_set1_epi32(_mm512_cmpeq_epi32_mask(cond_x, one), -1));
+
+            // Y
+            __m512i cond_y = _mm512_or_epi32(
+                _mm512_and_epi32(xi, _mm512_or_epi32(yi, zi)),
+                _mm512_and_epi32(yi, not_zi));
+            vy = _mm512_xor_epi32(vy, _mm512_maskz_set1_epi32(_mm512_cmpeq_epi32_mask(cond_y, one), -1));
+
+            // Z
+            __m512i cond_z = _mm512_or_epi32(
+                _mm512_and_epi32(xi, _mm512_and_epi32(not_yi, not_zi)),
+                _mm512_and_epi32(yi, not_zi));
+            vz = _mm512_xor_epi32(vz, _mm512_maskz_set1_epi32(_mm512_cmpeq_epi32_mask(cond_z, one), -1));
+
+            // We create masks (each bit represents a condition for an element)
+            __mmask16 mask_octants = _mm512_test_epi32_mask(zi, _mm512_set1_epi32(-1));
+            __mmask16 mask_mthVals_false = _mm512_testn_epi32_mask(yi, _mm512_set1_epi32(-1));
+            __mmask16 mask_else = ~mask_octants & mask_mthVals_false;
+
+            // Rot: tx = ty, ty = tz, tz = tx (original) when zi == 1
+            __m512i vx_orig = vx;
+            vx = _mm512_mask_mov_epi32(vx, mask_octants, vy);
+            vy = _mm512_mask_mov_epi32(vy, mask_octants, vz);
+            vz = _mm512_mask_mov_epi32(vz, mask_octants, vx_orig);
+
+            // Swap between tx and tz when (!zi && !yi)
+            __m512i tmp_vx = vx;
+            vx = _mm512_mask_mov_epi32(vx, mask_else, vz);
+            vz = _mm512_mask_mov_epi32(vz, mask_else, tmp_vx);
+        }
+
+        // Store final key (two 256-bit stores for 8x uint64_t keys)
+        _mm512_storeu_si512((__m512i *)&keys[i], key_lo);
+        _mm512_storeu_si512((__m512i *)&keys[i + 8], key_hi);
+    }
+#else
+    void encodeVectorized(const uint32_t *x, const uint32_t *y, const uint32_t *z, std::vector<key_t> &keys, size_t i) const override
+    {
+
+        //  Initialize 64-bit keys as 2 separate vectors since they are size_t and we are working with uint32
+        __m256i key_lo = _mm256_setzero_si256(); // For elements 0–3
+        __m256i key_hi = _mm256_setzero_si256(); // For elements 4–7
+
+        // Load the data
+        __m256i vx = _mm256_load_si256((__m256i *)(const uint32_t *)x);
+        __m256i vy = _mm256_load_si256((__m256i *)(const uint32_t *)y);
+        __m256i vz = _mm256_load_si256((__m256i *)(const uint32_t *)z);
+
+        __m256i one = _mm256_set1_epi32(1);
+        __m256i zero = _mm256_setzero_si256();
+        __m256i lookup_table_mortonToHilbert = _mm256_setr_epi32(0u, 1u, 3u, 2u, 7u, 6u, 4u, 5u);
+
+        alignas(32) uint32_t zi_arr[8], yi_arr[8]; // For rotations
+
+        for (int level = MAX_DEPTH - 1; level >= 0; level--)
+        {
+
+            // Find octant and append to the key (same as Morton codes)
+            __m256i shift = _mm256_set1_epi32(level);
+
+            // (x >> level) & 1u;
+            __m256i xi = _mm256_and_si256(_mm256_srlv_epi32(vx, shift), one);
+            __m256i yi = _mm256_and_si256(_mm256_srlv_epi32(vy, shift), one);
+            __m256i zi = _mm256_and_si256(_mm256_srlv_epi32(vz, shift), one);
+
+            __m256i octant = _mm256_or_si256(_mm256_or_si256(_mm256_slli_epi32(xi, 2), _mm256_slli_epi32(yi, 1)), zi);
+
+            __m256i hilbertVals = _mm256_permutevar8x32_epi32(lookup_table_mortonToHilbert, octant);
+
+            // Expand Morton to Hilbert (8x uint32_t) to 8x uint64_t
+            __m128i mth_lo = _mm256_extracti128_si256(hilbertVals, 0);
+            __m128i mth_hi = _mm256_extracti128_si256(hilbertVals, 1);
+            __m256i mth64_lo = _mm256_cvtepu32_epi64(mth_lo); // 4x uint64_t
+            __m256i mth64_hi = _mm256_cvtepu32_epi64(mth_hi); // 4x uint64_t
+
+            // Shift keys and combine them
+            key_lo = _mm256_slli_epi64(key_lo, 3);
+            key_hi = _mm256_slli_epi64(key_hi, 3);
+            key_lo = _mm256_or_si256(key_lo, mth64_lo);
+            key_hi = _mm256_or_si256(key_hi, mth64_hi);
+
+            // Turn x, y, z (Karnaugh mapped operations, check citation and Lam and Shapiro paper detailing 2D case
+            // for understanding how this works)
+            __m256i not_yi = _mm256_xor_si256(yi, one);
+            __m256i not_zi = _mm256_xor_si256(zi, one);
+
+            __m256i cond_x = _mm256_and_si256(xi, _mm256_or_si256(not_yi, zi));
+            __m256i mask_x = _mm256_sub_epi32(zero, cond_x);
+            vx = _mm256_xor_si256(vx, mask_x);
+
+            __m256i cond_y = _mm256_or_si256(_mm256_and_si256(xi, _mm256_or_si256(yi, zi)),
+                                             _mm256_and_si256(yi, not_zi));
+            __m256i mask_y = _mm256_sub_epi32(zero, cond_y);
+            vy = _mm256_xor_si256(vy, mask_y);
+
+            __m256i cond_z = _mm256_or_si256(_mm256_and_si256(xi, _mm256_and_si256(not_yi, not_zi)),
+                                             _mm256_and_si256(yi, not_zi));
+            __m256i mask_z = _mm256_sub_epi32(zero, cond_z);
+            vz = _mm256_xor_si256(vz, mask_z);
+
+            // rot_mask = zi ? 0xFFFFFFFF : 0x00000000
+            __m256i rot_mask = _mm256_cmpeq_epi32(zi, one);
+
+            // swap_mask = (!zi && !yi) ? 0xFFFFFFFF : 0x00000000
+            __m256i swap_mask = _mm256_and_si256(
+                _mm256_cmpeq_epi32(zi, zero),
+                _mm256_cmpeq_epi32(yi, zero));
+
+            // Rot: tx = ty, ty = tz, tz = tx (original) when zi == 1
+            __m256i tx_orig = vx;
+            vx = _mm256_blendv_epi8(vx, vy, rot_mask);      // tx = ty
+            vy = _mm256_blendv_epi8(vy, vz, rot_mask);      // ty = tz
+            vz = _mm256_blendv_epi8(vz, tx_orig, rot_mask); // tz = tx original
+
+            // Swap between tx and tz when (!zi && !yi)
+            __m256i tmp_vx = _mm256_blendv_epi8(vx, vz, swap_mask);
+            __m256i tmp_vz = _mm256_blendv_epi8(vz, vx, swap_mask);
+            vx = tmp_vx;
+            vz = tmp_vz;
+        }
+
+        // Store the final key
+        _mm256_storeu_si256((__m256i *)&keys[i], key_lo);
+        _mm256_storeu_si256((__m256i *)&keys[i + 4], key_hi);
+    }
+#endif
+
+    
     /// @brief Decodes the given key and puts the coordinates into x, y, z
     void decode(key_t code, coords_t &x, coords_t &y, coords_t &z) const override {
         // Initialize the coords values
@@ -103,6 +299,7 @@ public:
     inline double eps() const override { return EPS; }
     inline key_t upperBound() const override { return UPPER_BOUND; }
     inline uint32_t unusedBits() const override { return UNUSED_BITS; }
+    inline EncoderType getEncoder() const override { return EncoderType::HILBERT_ENCODER_3D; };
     inline std::string getEncoderName() const override { return "HilbertEncoder3D"; };
     inline std::string getShortEncoderName() const override { return "hilb"; };
 };

--- a/inc/PointEncoding/morton_encoder_3d.hpp
+++ b/inc/PointEncoding/morton_encoder_3d.hpp
@@ -35,6 +35,11 @@ class MortonEncoder3D : public PointEncoder {
         return libmorton::morton3D_64_encode(x, y, z);
     }
 
+    void encodeVectorized(const uint32_t *x, const uint32_t *y, const uint32_t *z, std::vector<key_t> &keys, size_t i) const override
+    {
+        return;
+    }
+
     /// @brief Decodes the given Morton key and puts the coordinates into x, y, z
     inline void decode(key_t code, coords_t &x, coords_t &y, coords_t &z) const override {
         libmorton::morton3D_64_decode(code, x, y, z);
@@ -51,6 +56,7 @@ class MortonEncoder3D : public PointEncoder {
     inline double eps() const override { return EPS; }
     inline key_t upperBound() const override { return UPPER_BOUND; }
     inline uint32_t unusedBits() const override { return UNUSED_BITS; }
+    inline EncoderType getEncoder() const override { return EncoderType::MORTON_ENCODER_3D; };
     inline std::string getEncoderName() const override { return "MortonEncoder3D"; };
     inline std::string getShortEncoderName() const override { return "mort"; };
 };

--- a/inc/PointEncoding/no_encoding.hpp
+++ b/inc/PointEncoding/no_encoding.hpp
@@ -14,6 +14,11 @@ class NoEncoding : public PointEncoder {
         return 0;
     }
 
+    void encodeVectorized(const uint32_t *x, const uint32_t *y, const uint32_t *z, std::vector<key_t> &keys, size_t i) const override
+    {
+        return;
+    }
+
     /// @brief Decodes the given Morton key and puts the coordinates into x, y, z
     inline void decode(key_t code, coords_t &x, coords_t &y, coords_t &z) const override {
         x = 0, y = 0, z = 0;
@@ -28,6 +33,7 @@ class NoEncoding : public PointEncoder {
     inline double eps() const override { return EPS; }
     inline key_t upperBound() const override { return UPPER_BOUND; }
     inline uint32_t unusedBits() const override { return UNUSED_BITS; }
+    inline EncoderType getEncoder() const override { return EncoderType::NO_ENCODING; };
     inline std::string getEncoderName() const { return "NoEncoding"; };
     inline std::string getShortEncoderName() const { return "none"; };
 };

--- a/inc/PointEncoding/point_encoder.hpp
+++ b/inc/PointEncoding/point_encoder.hpp
@@ -7,6 +7,7 @@
 #include "Geometry/PointMetadata.hpp"
 #include "benchmarking/encoding_log.hpp"
 #include "TimeWatcher.hpp"
+#include <immintrin.h>
 #include <bitset>
 
 // Base class for all Encoders
@@ -20,12 +21,14 @@ public:
     virtual ~PointEncoder() = default;
 
     virtual key_t encode(coords_t x, coords_t y, coords_t z) const = 0;
+    virtual void encodeVectorized(const uint32_t *x, const uint32_t *y, const uint32_t *z, std::vector<key_t> &keys, size_t i) const=0;
     virtual void decode(key_t code, coords_t &x, coords_t &y, coords_t &z) const = 0;
 
     virtual uint32_t maxDepth() const = 0;
     virtual double eps() const = 0;
     virtual key_t upperBound() const = 0;
     virtual uint32_t unusedBits() const = 0;
+    virtual EncoderType getEncoder() const =0; 
     virtual std::string getEncoderName() const = 0;
     virtual std::string getShortEncoderName() const = 0;
 
@@ -48,176 +51,405 @@ public:
 
     template <PointContainer Container>
     std::vector<key_t> encodePoints(const Container &points, const Box &bbox) const {
-        std::vector<key_t> codes(points.size());
+        size_t n = points.size();
+        std::vector<key_t> codes(n);
         #pragma omp parallel for schedule(static)
-            for(size_t i = 0; i < points.size(); i++) {
+            for(size_t i = 0; i < n; i++) {
                 codes[i] = encodeFromPoint(points[i], bbox);
             }
         return codes;
     }
-   
-    /**
-     * @brief Parallel radix sort implementation for the SFC reordering.
-     * 
-     * @returns The final array of encodings of the points
-     * 
-     * @details This implementation computes the codes multiple times for each element, but since SFC time is very fast,
-     * it does not matter. Saving the codes in another buffer array takes more time as a lot more memory may
-     * be needed
-     * 
-     */
+
+#if defined(__AVX512F__) && defined(__AVX512DQ__)
     template <PointContainer Container>
-    std::vector<key_t> sortPoints(Container &points, 
-        std::optional<std::vector<PointMetadata>> &meta_opt, const Box &bbox, std::shared_ptr<EncodingLog> log = nullptr) const {
-        size_t n = points.size();
-        // Choose 4, 8 or 16. 16 is less passes but requires more memory for the histograms and it offers better performance in most cases.
-        constexpr int BITS_PER_PASS = 16;
-        constexpr int NUM_BUCKETS = 1 << BITS_PER_PASS;
-        constexpr size_t BUCKET_MASK = NUM_BUCKETS - 1;
-        constexpr int NUM_PASSES = sizeof(key_t) * 8 / BITS_PER_PASS;
-    
-        TimeWatcher tw;
-        tw.start();
-    
-        Container buffer(n);
-        std::vector<PointMetadata> metadata_buffer;
-        if (meta_opt) metadata_buffer.resize(n);
-    
-        for (int pass = 0; pass < NUM_PASSES; pass++) {
-            int shift = pass * BITS_PER_PASS;
-    
-            // Step 1: Histogram
-            const int nThreads = omp_get_max_threads();
-            std::vector<std::vector<size_t>> localHist(nThreads, std::vector<size_t>(NUM_BUCKETS, 0));
-    
-            #pragma omp parallel
-            {
-                int tid = omp_get_thread_num();
-                auto& hist = localHist[tid];
-                #pragma omp for nowait schedule(static)
-                for (size_t i = 0; i < n; ++i) {
-                    size_t encoded_key = encodeFromPoint(points[i], bbox);
-                    size_t bucket = (encoded_key >> shift) & BUCKET_MASK;
-                    hist[bucket]++;
-                }
-            }
-    
-            // Step 2: Scan histograms to offsets
-            size_t offset = 0;
-            for (int b = 0; b < NUM_BUCKETS; b++) {
-                for (int t = 0; t < nThreads; t++) {
-                    size_t val = localHist[t][b];
-                    localHist[t][b] = offset;
-                    offset += val;
-                }
-            }
-    
-            // Step 3: Scatter to buffer using per-thread offsets
-            #pragma omp parallel
-            {
-                int tid = omp_get_thread_num();
-                auto& localOffset = localHist[tid];
-    
-                #pragma omp for schedule(static)
-                for (size_t i = 0; i < n; i++) {
-                    size_t encoded_key = encodeFromPoint(points[i], bbox);
-                    size_t bucket = (encoded_key >> shift) & BUCKET_MASK;
-                    size_t pos = localOffset[bucket]++;
-                    buffer.set(pos, points[i]);
-                    if (meta_opt) metadata_buffer[pos] = (*meta_opt)[i];
-                }
-            }
-    
-            std::swap(points, buffer);
-            if (meta_opt) std::swap(*meta_opt, metadata_buffer);
-        }
-    
-        tw.stop();
-        if (log) log->sortingTime = tw.getElapsedDecimalSeconds();
-        tw.start();
-    
-        // Final encoding
-        std::vector<key_t> keys(n);
-        #pragma omp parallel for schedule(static)
-        for (size_t i = 0; i < n; ++i) {
-            keys[i] = encodeFromPoint(points[i], bbox);
-        }
-    
-        tw.stop();
-        if (log) log->encodingTime = tw.getElapsedDecimalSeconds();
-    
-        return keys;
-    }
-
-    /**
-     * @brief This function computes the encodings of the points and sorts them in
-     * the given order. The points array is altered in-place here!
-     * 
-     * @details This is the main reordering function that we use to achieve spatial locality during neighbourhood
-     * searches. Encodings are first computed using encodeFromPoint, put into a pairs vector and then reordered.
-     * 
-     * @param points The input/output array of 3D points (i.e. the point cloud)
-     * @param codes The output array of computed codes (allocated here, only pass unallocated reference)
-     * @param bbox The precomputed global bounding box of points
-     * @param meta_opt The optional metadata of the point cloud (if Lpoint is used, it is contained on the struct). 
-     * meta_opt is a parallel array to points and will be sorted in the same order
-     */
-    template <PointContainer Container>
-    std::pair<std::vector<key_t>, Box> sortPoints(Container &points, 
-        std::optional<std::vector<PointMetadata>> &meta_opt, std::shared_ptr<EncodingLog> log = nullptr) const {
-        // Find the bbox
-        TimeWatcher tw;
-        tw.start();
-        Vector radii;
-        Point center = mbb(points, radii);
-        Box bbox = Box(center, radii);
-        tw.stop();
-        if(log) {
-            log->boundingBoxTime = tw.getElapsedDecimalSeconds();
-        }
-        // Call the regular sortPoints with metadata
-        return std::make_pair(sortPoints<Container>(points, meta_opt, bbox, log), bbox);
-    }
-
-
-    /**
-     * @brief Get the center and radii of an octant at a given octree level.
-     * 
-     * @tparam Encoder The encoder type.
-     * @param code The encoded key.
-     * @param level The level in the octree.
-     * @param bbox The bounding box.
-     * @param halfLengths The half lengths of the bounding box.
-     * @param precomputedRadii The precomputed radii corresponding to that level.
-     * @return A pair containing the center point and the radii vector.
-     */
-    inline Point getCenter(key_t code, uint32_t level, const Box &bbox, 
-            const double* halfLengths, const std::vector<Vector> precomputedRadii) const {
-        // Decode the points back into their integer coordinates
-        coords_t min_x, min_y, min_z;
-        decode(code, min_x, min_y, min_z);
-
-        // Now adjust the coordinates so they indicate the lowest code in the current level
-        // In Morton curves this is not needed, but in Hilbert curves it is, since it can return any corner instead of lower one we need
-        // Fun fact: finding this mistake when adding Hilbert curves took 6 hours of debugging
-        coords_t mask = ((1u << maxDepth()) - 1) ^ ((1u << (maxDepth() - level)) - 1);
-        min_x &= mask, min_y &= mask, min_z &= mask;
-
-        // Find the physical center by multiplying the encoding with the halfLength
-        // to get to the low corner of the cell, and then adding the radii of the cell
-        Point center = Point(
-            bbox.minX() + min_x * halfLengths[0] * 2, 
-            bbox.minY() + min_y * halfLengths[1] * 2, 
-            bbox.minZ() + min_z * halfLengths[2] * 2
-        ) + precomputedRadii[level];
-        
-        return center;
-    }
-    
-    /// @brief Count the leading zeros in a binary key.
-    constexpr uint32_t countLeadingZeros(key_t x) 
+    void encodePointsVectorized(const Container &points, const Box &bbox, std::vector<key_t> &keys) const
     {
-        #if defined(__GNUC__) || defined(__clang__)
+        size_t n = points.size();
+
+        if constexpr (std::is_same_v<Container, PointsSoA>) // Only to avoid compilation errors
+        {
+            const auto *soa = dynamic_cast<const PointsSoA *>(&points);
+            if (!soa)
+            {
+                std::cerr << "  [Error] Could not cast to PointsSoA\n";
+                return;
+            }
+
+            // Constants
+            __m512d bboxCenterX = _mm512_set1_pd(bbox.center().getX());
+            __m512d bboxCenterY = _mm512_set1_pd(bbox.center().getY());
+            __m512d bboxCenterZ = _mm512_set1_pd(bbox.center().getZ());
+            __m512d bboxRadiiX = _mm512_set1_pd(bbox.radii().getX());
+            __m512d bboxRadiiY = _mm512_set1_pd(bbox.radii().getY());
+            __m512d bboxRadiiZ = _mm512_set1_pd(bbox.radii().getZ());
+
+            __m512d two = _mm512_set1_pd(2.0);
+            __m512d scale = _mm512_set1_pd(1 << maxDepth());
+            __m512d maxCoord = _mm512_set1_pd((1u << maxDepth()) - 1u);
+
+            // 2 Iterations of 8 elements, and acumulates 16 elements at a time
+            #pragma omp parallel
+            {
+                #pragma omp for schedule(static)
+                for (size_t i = 0; i < n - 15; i += 16)
+                {
+                    alignas(64) double x_vals[8], y_vals[8], z_vals[8];
+                    alignas(64) uint32_t x[16], y[16], z[16];
+
+                    // Load 8 elements
+                    __m512d pointsX = _mm512_loadu_pd(soa->dataX() + i);
+                    __m512d pointsY = _mm512_loadu_pd(soa->dataY() + i);
+                    __m512d pointsZ = _mm512_loadu_pd(soa->dataZ() + i);
+
+                    // Put physical coords into the unit cube: ((p - center) + radii) / (2 * radii)
+                    __m512d x_transf = _mm512_div_pd(
+                        _mm512_add_pd(_mm512_sub_pd(pointsX, bboxCenterX), bboxRadiiX),
+                        _mm512_mul_pd(two, bboxRadiiX));
+                    __m512d y_transf = _mm512_div_pd(
+                        _mm512_add_pd(_mm512_sub_pd(pointsY, bboxCenterY), bboxRadiiY),
+                        _mm512_mul_pd(two, bboxRadiiY));
+                    __m512d z_transf = _mm512_div_pd(
+                        _mm512_add_pd(_mm512_sub_pd(pointsZ, bboxCenterZ), bboxRadiiZ),
+                        _mm512_mul_pd(two, bboxRadiiZ));
+
+                    // Scale to [0,2^L)^3 for morton encoding, handle edge case where coordinate could be 2^L if _transf is exactly 1.0
+                    __m512d x_scaled = _mm512_min_pd(_mm512_mul_pd(x_transf, scale), maxCoord);
+                    __m512d y_scaled = _mm512_min_pd(_mm512_mul_pd(y_transf, scale), maxCoord);
+                    __m512d z_scaled = _mm512_min_pd(_mm512_mul_pd(z_transf, scale), maxCoord);
+
+                    // Cast double to uint32_t
+                    __m256i x_uint = _mm512_cvttpd_epu32(x_scaled);
+                    __m256i y_uint = _mm512_cvttpd_epu32(y_scaled);
+                    __m256i z_uint = _mm512_cvttpd_epu32(z_scaled);
+
+                    // Store
+                    _mm256_store_si256((__m256i *)x, x_uint);
+                    _mm256_store_si256((__m256i *)y, y_uint);
+                    _mm256_store_si256((__m256i *)z, z_uint);
+
+                    // Second Iteration
+                    pointsX = _mm512_loadu_pd(soa->dataX() + i + 8);
+                    pointsY = _mm512_loadu_pd(soa->dataY() + i + 8);
+                    pointsZ = _mm512_loadu_pd(soa->dataZ() + i + 8);
+
+                    // Put physical coords into the unit cube: ((p - center) + radii) / (2 * radii)
+                    x_transf = _mm512_div_pd(
+                        _mm512_add_pd(_mm512_sub_pd(pointsX, bboxCenterX), bboxRadiiX),
+                        _mm512_mul_pd(two, bboxRadiiX));
+                    y_transf = _mm512_div_pd(
+                        _mm512_add_pd(_mm512_sub_pd(pointsY, bboxCenterY), bboxRadiiY),
+                        _mm512_mul_pd(two, bboxRadiiY));
+                    z_transf = _mm512_div_pd(
+                        _mm512_add_pd(_mm512_sub_pd(pointsZ, bboxCenterZ), bboxRadiiZ),
+                        _mm512_mul_pd(two, bboxRadiiZ));
+
+                    // Scale to [0,2^L)^3 for morton encoding, handle edge case where coordinate could be 2^L if _transf is exactly 1.0
+                    x_scaled = _mm512_min_pd(_mm512_mul_pd(x_transf, scale), maxCoord);
+                    y_scaled = _mm512_min_pd(_mm512_mul_pd(y_transf, scale), maxCoord);
+                    z_scaled = _mm512_min_pd(_mm512_mul_pd(z_transf, scale), maxCoord);
+
+                    // Cast double to uint32_t
+                    x_uint = _mm512_cvttpd_epu32(x_scaled);
+                    y_uint = _mm512_cvttpd_epu32(y_scaled);
+                    z_uint = _mm512_cvttpd_epu32(z_scaled);
+
+                    // Store
+                    _mm256_store_si256((__m256i *)&x[8], x_uint);
+                    _mm256_store_si256((__m256i *)&y[8], y_uint);
+                    _mm256_store_si256((__m256i *)&z[8], z_uint);
+
+                    encodeVectorized(x, y, z, keys, i);
+                }
+
+                    // Process remaining items
+                    #pragma omp single nowait
+                    for (size_t i = n - (n % 16); i < n; ++i)
+                    {
+                        keys[i] = encodeFromPoint(points[i], bbox);
+                    }
+                }
+            }
+        }
+#else
+    template <PointContainer Container>
+    void encodePointsVectorized(const Container &points, const Box &bbox, std::vector<key_t> &keys) const
+    {
+
+        size_t n = points.size();
+
+        if constexpr (std::is_same_v<Container, PointsSoA>) // Only to avoid compilation errors
+        {
+            const auto *soa = dynamic_cast<const PointsSoA *>(&points);
+            if (!soa)
+            {
+                std::cerr << "Error: Could not cast to PointsSoA\n";
+                return;
+            }
+
+            // Constants
+            __m256d bboxCenterX = _mm256_set1_pd(bbox.center().getX());
+            __m256d bboxCenterY = _mm256_set1_pd(bbox.center().getY());
+            __m256d bboxCenterZ = _mm256_set1_pd(bbox.center().getZ());
+            __m256d bboxRadiiX = _mm256_set1_pd(bbox.radii().getX());
+            __m256d bboxRadiiY = _mm256_set1_pd(bbox.radii().getY());
+            __m256d bboxRadiiZ = _mm256_set1_pd(bbox.radii().getZ());
+
+            __m256d two = _mm256_set1_pd(2.0);
+            __m256d scale = _mm256_set1_pd(1 << maxDepth());
+            __m256d maxCoord = _mm256_set1_pd((1u << maxDepth()) - 1u);
+
+                // 2 Iterations of 4 elements, and acumulates 8 elements at a time
+                #pragma omp parallel
+                {
+                    #pragma omp for schedule(static)
+                    for (size_t i = 0; i < n - 7; i += 8)
+                    {
+                        alignas(32) uint32_t x[8], y[8], z[8];
+
+                        // Load 4 elements
+                        __m256d pointsX = _mm256_load_pd(soa->dataX() + i);
+                        __m256d pointsY = _mm256_load_pd(soa->dataY() + i);
+                        __m256d pointsZ = _mm256_load_pd(soa->dataZ() + i);
+
+                        // Put physical coords into the unit cube: ((p - center) + radii) / (2 * radii)
+                        __m256d x_transf = _mm256_div_pd(_mm256_add_pd(_mm256_sub_pd(pointsX, bboxCenterX), bboxRadiiX), _mm256_mul_pd(two, bboxRadiiX));
+                        __m256d y_transf = _mm256_div_pd(_mm256_add_pd(_mm256_sub_pd(pointsY, bboxCenterY), bboxRadiiY), _mm256_mul_pd(two, bboxRadiiY));
+                        __m256d z_transf = _mm256_div_pd(_mm256_add_pd(_mm256_sub_pd(pointsZ, bboxCenterZ), bboxRadiiZ), _mm256_mul_pd(two, bboxRadiiZ));
+
+                        // Scale to [0,2^L)^3 for morton encoding, handle edge case where coordinate could be 2^L if _transf is exactly 1.0
+                        __m256d x_scaled = _mm256_min_pd(_mm256_mul_pd(x_transf, scale), maxCoord);
+                        __m256d y_scaled = _mm256_min_pd(_mm256_mul_pd(y_transf, scale), maxCoord);
+                        __m256d z_scaled = _mm256_min_pd(_mm256_mul_pd(z_transf, scale), maxCoord);
+
+                        // Store
+                        alignas(32) double x_vals[4], y_vals[4], z_vals[4];
+                        _mm256_store_pd(x_vals, x_scaled);
+                        _mm256_store_pd(y_vals, y_scaled);
+                        _mm256_store_pd(z_vals, z_scaled);
+
+                        for (int j = 0; j < 4; ++j)
+                        {
+                            x[j] = static_cast<uint32_t>(x_vals[j]);
+                            y[j] = static_cast<uint32_t>(y_vals[j]);
+                            z[j] = static_cast<uint32_t>(z_vals[j]);
+                        }
+
+                        // Second iteration
+                        pointsX = _mm256_load_pd(soa->dataX() + i + 4);
+                        pointsY = _mm256_load_pd(soa->dataY() + i + 4);
+                        pointsZ = _mm256_load_pd(soa->dataZ() + i + 4);
+
+                        // Put physical coords into the unit cube: ((p - center) + radii) / (2 * radii)
+                        x_transf = _mm256_div_pd(_mm256_add_pd(_mm256_sub_pd(pointsX, bboxCenterX), bboxRadiiX), _mm256_mul_pd(two, bboxRadiiX));
+                        y_transf = _mm256_div_pd(_mm256_add_pd(_mm256_sub_pd(pointsY, bboxCenterY), bboxRadiiY), _mm256_mul_pd(two, bboxRadiiY));
+                        z_transf = _mm256_div_pd(_mm256_add_pd(_mm256_sub_pd(pointsZ, bboxCenterZ), bboxRadiiZ), _mm256_mul_pd(two, bboxRadiiZ));
+
+                        // Scale to [0,2^L)^3 for morton encoding, handle edge case where coordinate could be 2^L if _transf is exactly 1.0
+                        x_scaled = _mm256_min_pd(_mm256_mul_pd(x_transf, scale), maxCoord);
+                        y_scaled = _mm256_min_pd(_mm256_mul_pd(y_transf, scale), maxCoord);
+                        z_scaled = _mm256_min_pd(_mm256_mul_pd(z_transf, scale), maxCoord);
+
+                        // Store
+                        _mm256_store_pd(x_vals, x_scaled);
+                        _mm256_store_pd(y_vals, y_scaled);
+                        _mm256_store_pd(z_vals, z_scaled);
+
+                        for (int j = 0; j < 4; ++j)
+                        {
+                            x[j + 4] = static_cast<uint32_t>(x_vals[j]);
+                            y[j + 4] = static_cast<uint32_t>(y_vals[j]);
+                            z[j + 4] = static_cast<uint32_t>(z_vals[j]);
+                        }
+
+                        encodeVectorized(x, y, z, keys, i);
+                    }
+
+                    // Process remaining items
+                    #pragma omp single nowait
+                    for (size_t i = n - (n % 4); i < n; ++i)
+                    {
+                        keys[i] = encodeFromPoint(points[i], bbox);
+                    }
+                }
+            }
+        }
+    #endif
+
+        /**
+         * @brief Parallel radix sort implementation for the SFC reordering.
+         *
+         * @returns The final array of encodings of the points
+         */
+        template <PointContainer Container>
+        std::vector<key_t> sortPoints_Optimized(Container &points,
+                                                std::optional<std::vector<PointMetadata>> &meta_opt, const Box &bbox, std::shared_ptr<EncodingLog> log = nullptr) const
+        {
+            size_t n = points.size();
+            constexpr int BITS_PER_PASS = 8;
+            constexpr int NUM_BUCKETS = 1 << BITS_PER_PASS;
+            constexpr size_t BUCKET_MASK = NUM_BUCKETS - 1;
+            constexpr int NUM_PASSES = sizeof(key_t) * 8 / BITS_PER_PASS;
+
+            std::vector<key_t> keys;
+
+            TimeWatcher tw;
+            tw.start();
+
+            // Encoding
+            if (mainOptions.containerType == ContainerType::SoA && this->getEncoder() == EncoderType::HILBERT_ENCODER_3D)
+            {
+                keys.resize(n);
+                encodePointsVectorized(points, bbox, keys);
+            }
+            else
+            {
+                keys = encodePoints(points, bbox);
+            }
+
+            tw.stop();
+            if (log)
+                log->encodingTime = tw.getElapsedDecimalSeconds();
+
+            tw.start();
+
+            std::vector<key_t> buffer(n);
+            Container bufferDecoded(n);
+            std::vector<PointMetadata> metadata_buffer;
+            if (meta_opt)
+                metadata_buffer.resize(n);
+
+            for (int pass = 0; pass < NUM_PASSES; pass++)
+            {
+                int shift = pass * BITS_PER_PASS;
+
+                const int nThreads = omp_get_max_threads();
+                std::vector<std::vector<size_t>> localHist(nThreads, std::vector<size_t>(NUM_BUCKETS, 0));
+
+                // Step 1: Histogram
+                #pragma omp parallel
+                {
+                    auto &hist = localHist[omp_get_thread_num()];
+                    #pragma omp for schedule(static)
+                    for (size_t i = 0; i < n; ++i)
+                    {
+                        size_t bucket = (keys[i] >> shift) & BUCKET_MASK;
+                        hist[bucket]++;
+                    }
+
+                    // Step 2: Scan histograms to offsets
+                    #pragma omp single
+                    {
+                        size_t offset = 0;
+                        for (int b = 0; b < NUM_BUCKETS; b++)
+                        {
+                            for (int t = 0; t < nThreads; t++)
+                            {
+                                size_t val = localHist[t][b];
+                                localHist[t][b] = offset;
+                                offset += val;
+                            }
+                        }
+                    }
+
+                    // Step 3: Scatter to buffer using per-thread offsets
+                    auto &localOffset = localHist[omp_get_thread_num()];
+                    #pragma omp for schedule(static)
+                    for (size_t i = 0; i < n; i++)
+                    {
+                        size_t bucket = (keys[i] >> shift) & BUCKET_MASK;
+                        size_t pos = localOffset[bucket]++;
+                        buffer[pos] = keys[i];
+                        bufferDecoded.set(pos, points[i]);
+                        if (meta_opt)
+                            metadata_buffer[pos] = (*meta_opt)[i];
+                    }
+                }
+
+                std::swap(points, bufferDecoded);
+                std::swap(keys, buffer);
+                if (meta_opt)
+                    std::swap(*meta_opt, metadata_buffer);
+            }
+
+            tw.stop();
+            if (log)
+                log->sortingTime = tw.getElapsedDecimalSeconds();
+
+            return keys;
+        }
+
+        /**
+         * @brief This function computes the encodings of the points and sorts them in
+         * the given order. The points array is altered in-place here!
+         *
+         * @details This is the main reordering function that we use to achieve spatial locality during neighbourhood
+         * searches. Encodings are first computed using encodeFromPoint, put into a pairs vector and then reordered.
+         *
+         * @param points The input/output array of 3D points (i.e. the point cloud)
+         * @param codes The output array of computed codes (allocated here, only pass unallocated reference)
+         * @param bbox The precomputed global bounding box of points
+         * @param meta_opt The optional metadata of the point cloud (if Lpoint is used, it is contained on the struct).
+         * meta_opt is a parallel array to points and will be sorted in the same order
+         */
+        template <PointContainer Container>
+        std::pair<std::vector<key_t>, Box> sortPoints(Container &points,
+                                                      std::optional<std::vector<PointMetadata>> &meta_opt, std::shared_ptr<EncodingLog> log = nullptr) const
+        {
+            // Find the bbox
+            TimeWatcher tw;
+            tw.start();
+            Vector radii;
+            Point center = mbb(points, radii);
+            Box bbox = Box(center, radii);
+            tw.stop();
+            if (log)
+            {
+                log->boundingBoxTime = tw.getElapsedDecimalSeconds();
+            }
+
+            // Call the regular sortPoints with metadata
+            return std::make_pair(sortPoints_Optimized<Container>(points, meta_opt, bbox, log), bbox);
+        }
+
+        /**
+         * @brief Get the center and radii of an octant at a given octree level.
+         *
+         * @tparam Encoder The encoder type.
+         * @param code The encoded key.
+         * @param level The level in the octree.
+         * @param bbox The bounding box.
+         * @param halfLengths The half lengths of the bounding box.
+         * @param precomputedRadii The precomputed radii corresponding to that level.
+         * @return A pair containing the center point and the radii vector.
+         */
+        inline Point getCenter(key_t code, uint32_t level, const Box &bbox,
+                               const double *halfLengths, const std::vector<Vector> precomputedRadii) const
+        {
+            // Decode the points back into their integer coordinates
+            coords_t min_x, min_y, min_z;
+            decode(code, min_x, min_y, min_z);
+
+            // Now adjust the coordinates so they indicate the lowest code in the current level
+            // In Morton curves this is not needed, but in Hilbert curves it is, since it can return any corner instead of lower one we need
+            // Fun fact: finding this mistake when adding Hilbert curves took 6 hours of debugging
+            coords_t mask = ((1u << maxDepth()) - 1) ^ ((1u << (maxDepth() - level)) - 1);
+            min_x &= mask, min_y &= mask, min_z &= mask;
+
+            // Find the physical center by multiplying the encoding with the halfLength
+            // to get to the low corner of the cell, and then adding the radii of the cell
+            Point center = Point(
+                               bbox.minX() + min_x * halfLengths[0] * 2,
+                               bbox.minY() + min_y * halfLengths[1] * 2,
+                               bbox.minZ() + min_z * halfLengths[2] * 2) +
+                           precomputedRadii[level];
+
+            return center;
+        }
+
+        /// @brief Count the leading zeros in a binary key.
+        constexpr uint32_t countLeadingZeros(key_t x)
+        {
+#if defined(__GNUC__) || defined(__clang__)
             if (x == 0) return 8 * sizeof(key_t);
             // 64-bit keys
             if constexpr (sizeof(key_t) == 8) {
@@ -227,7 +459,7 @@ public:
             else {
                 return __builtin_clz(x);
             }
-        #else
+#else
             uint32_t depth = 0;
             for (; x != 1; x >>= 3, depth++);
             return depth;


### PR DESCRIPTION
Optimized version for octrees-benchmark. 

The execution times of **point sorting** and **Hilbert encoding** have been optimized by vectorization (mainly)